### PR TITLE
fix(search): 修复中文人物搜尋时繁体/简体检索体验度不理想的问题

### DIFF
--- a/custom_settings.json
+++ b/custom_settings.json
@@ -13,6 +13,5 @@
     "ai": true,
     "base_url": "https://api.groq.com/openai/v1/chat/completions",
     "model": "llama-3.3-70b-versatile",
-    "api_key":"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",
-    "locale_lang": "zh-tw"
+    "api_key":"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"
 }

--- a/custom_settings.json
+++ b/custom_settings.json
@@ -13,5 +13,6 @@
     "ai": true,
     "base_url": "https://api.groq.com/openai/v1/chat/completions",
     "model": "llama-3.3-70b-versatile",
-    "api_key":"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"
+    "api_key":"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",
+    "locale_lang": "zh-tw"
 }

--- a/scripts/character_select.py
+++ b/scripts/character_select.py
@@ -28,11 +28,14 @@ try:
 
     if not launch.is_installed("colorama"):
             launch.run_pip("install colorama")
+    if not launch.is_installed("zhconv"):
+            launch.run_pip("install zhconv")
 except:
     pass
 
 try:
     from colorama import just_fix_windows_console, Fore, Style
+    from zhconv import convert as zh_convert
     just_fix_windows_console()
 except:
     pass
@@ -118,7 +121,9 @@ class CharacterSelect(scripts.Script):
         #    self.hm_config_1_img.append(item)
         
         self.localizations = "zh_TW.json"
-        self.localizations_component = self.get_config2(self.localizations)
+        self.localizations_component = dict()
+        for key,value in self.get_config2(self.localizations).items():
+            self.localizations_component[zh_convert(key, self.settings["locale_lang"])] = value
         self.relocalizations_component = {value: key for key, value in self.localizations_component.items()}
 
         self.hm1prompt = ""

--- a/scripts/character_select.py
+++ b/scripts/character_select.py
@@ -28,14 +28,11 @@ try:
 
     if not launch.is_installed("colorama"):
             launch.run_pip("install colorama")
-    if not launch.is_installed("zhconv"):
-            launch.run_pip("install zhconv")
 except:
     pass
 
 try:
     from colorama import just_fix_windows_console, Fore, Style
-    from zhconv import convert as zh_convert
     just_fix_windows_console()
 except:
     pass
@@ -121,9 +118,7 @@ class CharacterSelect(scripts.Script):
         #    self.hm_config_1_img.append(item)
         
         self.localizations = "zh_TW.json"
-        self.localizations_component = dict()
-        for key,value in self.get_config2(self.localizations).items():
-            self.localizations_component[zh_convert(key, self.settings["locale_lang"])] = value
+        self.localizations_component = self.get_config2(self.localizations)
         self.relocalizations_component = {value: key for key, value in self.localizations_component.items()}
 
         self.hm1prompt = ""

--- a/settings.json
+++ b/settings.json
@@ -13,5 +13,6 @@
     "ai": false,
     "base_url": "https://api.groq.com/openai/v1/chat/completions",
     "model": "llama-3.3-70b-versatile",
-    "api_key":""
+    "api_key":"",
+    "locale_lang": "zh-tw"
 }

--- a/settings.json
+++ b/settings.json
@@ -13,6 +13,5 @@
     "ai": false,
     "base_url": "https://api.groq.com/openai/v1/chat/completions",
     "model": "llama-3.3-70b-versatile",
-    "api_key":"",
-    "locale_lang": "zh-tw"
+    "api_key":""
 }


### PR DESCRIPTION
通过custom_settings.json中的locale_lang属性来配置用户当前的语言环境(支持zh-cn,zh-sg,zh-tw,zh-hk,zh-mo),从而在中文人物搜索时得到较好的使用体验

Closes #3

修复缘由: 默认情况插件仅支持繁中的语言环境，对简中的用户使用体验不好。同时在zh_TW.json中维护的角色姓名存在简体中文和繁体中文混杂的情况，对繁中语言环境的用户也不大友好。一开始预想是在gr.Dropdown下面，对输入的中文统一转换为繁中，然后和统一转换为繁中的角色列表做匹配，但是gr.Dropdown不支持自定义过滤函数，实施起来比较麻烦。考虑到用户一旦语言环境确定后，用户输入的中文基本不存在简中和繁中混合的情况，因而统一将角色列表转换为用户语言环境的中文来做匹配

测试验证: 改动已在本地Web UI环境测试正常